### PR TITLE
Fix default branch placeholder typo

### DIFF
--- a/repo-config.yml
+++ b/repo-config.yml
@@ -10,7 +10,7 @@ repo:
   allow_update_branch: true
 
 branchProtection:
-  - branch: '__DEFALT_BRANCH__'
+  - branch: '__DEFAULT_BRANCH__'
     required_status_checks:
       strict: false
       contexts: ALL


### PR DESCRIPTION
## Summary
- fix the `repo-config.yml` placeholder for the default branch

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68401fd9e72c832a963c5ef424432620