### PR TITLE
Modernise security-scan workflow + fix templated security.yml indent

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -7,36 +7,22 @@ jobs:
     name: CodeQL
     if: github.event.repository.visibility == 'public'
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      with:
-        fetch-depth: 2
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@3ebbd71c74ef574dbc558c82f70e52732c8b44fe # v2.2.1
-      continue-on-error: true
-      id: initcodeql
-    - name: Autobuild
-      if: steps.initcodeql.outcome == 'success'
-      uses: github/codeql-action/autobuild@3ebbd71c74ef574dbc558c82f70e52732c8b44fe # v2.2.1
-    - name: Perform CodeQL Analysis
-      if: steps.initcodeql.outcome == 'success'
-      uses: github/codeql-action/analyze@3ebbd71c74ef574dbc558c82f70e52732c8b44fe # v2.2.1
-
-  ShiftLeft:
-    if: github.event.repository.visibility == 'public'
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-    - name: Perform ShiftLeft Scan
-      uses: ShiftLeftSecurity/scan-action@master
-      env:
-        WORKSPACE: ""
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SCAN_AUTO_BUILD: true
-      with:
-        output: reports
-    - name: Upload report
-      uses: github/codeql-action/upload-sarif@3ebbd71c74ef574dbc558c82f70e52732c8b44fe # v2.2.1
-      with:
-        sarif_file: reports
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 2
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3.30.0
+        continue-on-error: true
+        id: initcodeql
+      - name: Autobuild
+        if: steps.initcodeql.outcome == 'success'
+        uses: github/codeql-action/autobuild@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3.30.0
+      - name: Perform CodeQL Analysis
+        if: steps.initcodeql.outcome == 'success'
+        uses: github/codeql-action/analyze@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3.30.0

--- a/repo-config.yml
+++ b/repo-config.yml
@@ -93,18 +93,18 @@ files:
     visibility: public
     content: |
       name: "Security Scanning"
-    on:
-      push:
-        branches: [main, master]
-      pull_request:
-        branches: [main, master]
-    jobs:
-      scan:
-        name: Security Scan
-        uses: chrisns/.github/.github/workflows/security-scan.yml@main
-        permissions:
-          security-events: write
-          statuses: write
+      on:
+        push:
+          branches: [main, master]
+        pull_request:
+          branches: [main, master]
+      jobs:
+        scan:
+          name: Security Scan
+          uses: chrisns/.github/.github/workflows/security-scan.yml@main
+          permissions:
+            security-events: write
+            statuses: write
 
   "SECURITY.md":
     visibility: public


### PR DESCRIPTION
## Why
- `security-scan.yml` reusable workflow used CodeQL action v2 (retired) and `ShiftLeftSecurity/scan-action@master` (unmaintained), so every consumer repo's Security Scan job failed at workflow-file dispatch.
- `repo-config.yml`'s entry for `.github/workflows/security.yml` had `on:` and `jobs:` indented as siblings of the `content: |` key, not inside it. The templated file landing in every repo was just `name: "Security Scanning"\n` (26 bytes), failing to dispatch any job.

## What
- Bump CodeQL action to v3.30.0 across init/autobuild/analyze.
- Bump actions/checkout to v5.0.0.
- Drop the broken ShiftLeft job (re-add a modern scanner separately if wanted).
- Re-indent `on:`/`jobs:` to live inside the `content: |` block.

## Test plan
- [ ] Once merged, repomanager cron picks up the corrected file in repo-config.yml and rolls it out via templated-files PRs.
- [ ] Security Scan check goes green on consumer repos.