### PR TITLE
Add contents/actions read perms to security scan template

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,4 +10,6 @@ jobs:
     uses: chrisns/.github/.github/workflows/security-scan.yml@main
     permissions:
       security-events: write
+      contents: read
+      actions: read
       statuses: write


### PR DESCRIPTION
## Summary
The caller template at `.github/workflows/security.yml` only granted `security-events: write` and `statuses: write`, but the reusable `security-scan.yml` it invokes runs CodeQL which needs `contents: read` (for checkout) and `actions: read` (for analyze).

Downstream repos using this template hit:

> The nested job 'CodeQL' is requesting 'actions: read, contents: read', but is only allowed 'actions: none, contents: none'.

…and the Security Scanning workflow fails at startup on every run.

This was first noticed and patched downstream in chrisns/talks#653, but the-repository-manager bot keeps proposing reverts (e.g. chrisns/talks#654) because this template is the source of truth. Fixing it here so it sticks.

## Test plan
- [ ] Next templated-files PR opened by the-repository-manager no longer strips the two read permissions
- [ ] Security Scanning workflows on downstream repos start successfully